### PR TITLE
Add comments to hook tests and document test coverage

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,6 +177,19 @@ CREATE POLICY "Users can view groups they belong to" ON groups
   );
 ```
 
+## Tests
+
+<details>
+<summary>What do the hook tests cover?</summary>
+
+- **useAddExpense** – verifies that new expenses are created correctly and that splits are calculated for both equal and share modes.
+- **useDeleteExpense** – ensures an expense can be removed via the API.
+- **useExpenses** – checks that expenses are fetched for a given group.
+- **useGroups** – tests fetching existing groups on mount and creating a new group.
+- **useSupabase** – confirms the hook returns the configured Supabase client.
+
+</details>
+
 ## Development Notes
 
 ### TODO Items

--- a/src/hooks/__tests__/useDeleteExpense.test.ts
+++ b/src/hooks/__tests__/useDeleteExpense.test.ts
@@ -1,6 +1,8 @@
 import { renderHook, act } from '@testing-library/react';
+// Hook responsible for deleting an expense by id
 import { useDeleteExpense } from '../useDeleteExpense';
 
+// Mock Supabase client used by the hook
 jest.mock('../../lib/supabase', () => ({
   supabase: {
     from: jest.fn(),
@@ -9,12 +11,15 @@ jest.mock('../../lib/supabase', () => ({
 
 import { supabase } from '../../lib/supabase';
 
+// Basic tests ensuring the deleteExpense helper properly issues a delete request
 describe('useDeleteExpense', () => {
   beforeEach(() => {
+    // Clear mocks before each test run
     jest.resetAllMocks();
   });
 
   it('deletes an expense', async () => {
+    // Mock chained supabase methods for deletion
     const eq = jest.fn().mockResolvedValue({ error: null });
     const del = jest.fn(() => ({ eq }));
     (supabase.from as jest.Mock).mockReturnValue({ delete: del });

--- a/src/hooks/__tests__/useExpenses.test.ts
+++ b/src/hooks/__tests__/useExpenses.test.ts
@@ -1,6 +1,8 @@
 import { renderHook, act } from '@testing-library/react';
+// Hook for retrieving expenses belonging to a group
 import { useExpenses } from '../useExpenses';
 
+// Mock the Supabase client module
 jest.mock('../../lib/supabase', () => ({
   supabase: {
     from: jest.fn(),
@@ -9,25 +11,30 @@ jest.mock('../../lib/supabase', () => ({
 
 import { supabase } from '../../lib/supabase';
 
+// Tests for fetching a list of expenses for a specific group
 describe('useExpenses', () => {
   beforeEach(() => {
+    // Reset mocks between tests
     jest.resetAllMocks();
   });
 
   it('fetches expenses for a group', async () => {
     const data = [{ id: 'e1' }];
+    // Mock the chain of supabase query builders
     const order = jest.fn().mockResolvedValue({ data, error: null });
     const eq = jest.fn(() => ({ order }));
     const select = jest.fn(() => ({ eq }));
     (supabase.from as jest.Mock).mockReturnValue({ select });
 
+    // Render the hook with a sample group id
     const { result } = renderHook(() => useExpenses('g1'));
     
     await act(async () => {
-      // Wait for the effect to run
+      // Wait for the effect inside the hook to complete
       await new Promise(resolve => setTimeout(resolve, 0));
     });
 
+    // The hook should expose the fetched expenses and call the correct queries
     expect(result.current.expenses).toEqual(data);
     expect(supabase.from).toHaveBeenCalledWith('expenses');
     expect(select).toHaveBeenCalledWith('*');

--- a/src/hooks/__tests__/useGroups.test.ts
+++ b/src/hooks/__tests__/useGroups.test.ts
@@ -1,6 +1,8 @@
 import { renderHook, act } from '@testing-library/react';
+// Hook used for fetching and creating groups
 import { useGroups } from '../useGroups';
 
+// Mock the Supabase module so tests don't hit the network
 jest.mock('../../lib/supabase', () => ({
   supabase: {
     auth: { getUser: jest.fn() },
@@ -10,8 +12,10 @@ jest.mock('../../lib/supabase', () => ({
 
 import { supabase } from '../../lib/supabase';
 
+// Test suite for the useGroups hook which handles retrieving and creating groups
 describe('useGroups', () => {
   beforeEach(() => {
+    // Reset mock implementations before each test
     jest.resetAllMocks();
   });
 
@@ -22,6 +26,7 @@ describe('useGroups', () => {
     const membershipsData = [{ group_id: 'g1' }];
     const groupsData = [{ id: 'g1', name: 'test' }];
 
+    // Mock out the various table queries used by the hook
     (supabase.from as jest.Mock).mockImplementation((table: string) => {
       if (table === 'memberships') {
         return {
@@ -40,13 +45,15 @@ describe('useGroups', () => {
       return {} as any;
     });
 
+    // Render the hook which automatically fetches groups on mount
     const { result } = renderHook(() => useGroups());
     
     await act(async () => {
-      // Wait for the effect to run
+      // Wait for the initial fetch effect to complete
       await new Promise(resolve => setTimeout(resolve, 0));
     });
 
+    // The hook should store the groups and not report an error
     expect(result.current.groups).toEqual(groupsData);
     expect(result.current.error).toBeNull();
   });
@@ -57,6 +64,7 @@ describe('useGroups', () => {
 
     const group = { id: 'g1', name: 'New' };
 
+    // Mock database calls for inserting the group and membership
     (supabase.from as jest.Mock).mockImplementation((table: string) => {
       if (table === 'groups') {
         return {
@@ -76,6 +84,7 @@ describe('useGroups', () => {
     await act(async () => {
       resultValue = await result.current.createGroup('New');
     });
+    // Return value should be the created group and the correct table invoked
     expect(resultValue).toEqual(group);
 
     expect(supabase.from).toHaveBeenCalledWith('groups');

--- a/src/hooks/__tests__/useSupabase.test.ts
+++ b/src/hooks/__tests__/useSupabase.test.ts
@@ -1,11 +1,14 @@
 import { useSupabase } from '../useSupabase';
+// The actual supabase client is mocked in this test
 import { supabase as supabaseClient } from '../../lib/supabase';
 
+// Provide a simple mock supabase client to verify the hook returns it
 jest.mock('../../lib/supabase', () => ({
   supabase: { test: 'client' },
 }));
 
 describe('useSupabase', () => {
+  // The hook should simply expose the mocked client
   it('returns the supabase client', () => {
     const { supabase } = useSupabase();
     expect(supabase).toEqual({ test: 'client' });


### PR DESCRIPTION
## Summary
- add inline comments to hook tests for clarity
- describe available tests in the README

## Testing
- `npm install --legacy-peer-deps`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688134c2928c8323837f07f6049f0d99